### PR TITLE
Improve backend integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,63 @@
-# Run and deploy your AI Studio app
+# Profit Tracker
 
-This contains everything you need to run your app locally.
+This repository contains a React frontend (Vite) and a Node/Express backend. The
+frontend communicates with the backend through HTTP requests. The instructions
+below describe how to set up both parts for local development.
 
-## Run Locally
+## Prerequisites
 
-**Prerequisites:**  Node.js
+- [Node.js](https://nodejs.org/) (version 18 or higher recommended)
+- A running PostgreSQL instance for the backend
 
+## Running the Backend
+
+1. Navigate to the `backend` folder:
+   ```bash
+   cd backend
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Create a `.env` file inside `backend` with the following variables:
+   ```bash
+   DATABASE_URL=postgres://user:password@localhost:5432/profit_tracker
+   JWT_SECRET=some-secret-key
+   # Address of the frontend for CORS. Change if the frontend runs on a
+   # different host/port.
+   CLIENT_URL=http://localhost:3000
+   ```
+4. Start the backend in development mode:
+   ```bash
+   npm run dev
+   ```
+   The API will be available at `http://localhost:3001/api`.
+
+## Running the Frontend
+
+From the repository root:
 
 1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+   ```bash
+   npm install
+   ```
+2. Create a `.env.local` file for Vite environment variables (optional):
+   ```bash
+   GEMINI_API_KEY=your-gemini-key
+   # Override the backend URL if it is not http://localhost:3001/api
+   VITE_API_URL=http://localhost:3001/api
+   ```
+3. Start the frontend:
+   ```bash
+   npm run dev
+   ```
+   The application will open at `http://localhost:3000` and communicate with the
+   backend using the URL defined in `VITE_API_URL`.
+
+## Notes
+
+- The frontend uses the `VITE_API_URL` variable in `utils/apiClient.ts` to decide
+  which backend URL to call. If this variable is not provided, it defaults to
+  `http://localhost:3001/api`.
+- When deploying, make sure both the backend and frontend are configured with
+  the correct environment variables for your production environment.

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -1,5 +1,12 @@
 
-const API_BASE_URL = 'http://localhost:3001/api'; // Default backend URL. Replace with import.meta.env.VITE_API_URL if using Vite.
+// Prefer the URL provided via Vite's environment variables when available so
+// the frontend can easily point to a different backend in different
+// environments (e.g. production or a container).  Fallback to the local
+// development server URL.
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_URL)
+    ? import.meta.env.VITE_API_URL
+    : 'http://localhost:3001/api';
 
 interface ApiClientOptions extends RequestInit {
   useAuth?: boolean;


### PR DESCRIPTION
## Summary
- make API URL configurable with `VITE_API_URL`
- document how to run the backend and frontend together in README

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684074c18a04832da103b996550162fd