### PR TITLE
Add Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ below describe how to set up both parts for local development.
   `http://localhost:3001/api`.
 - When deploying, make sure both the backend and frontend are configured with
   the correct environment variables for your production environment.
+
+## Running with Docker
+
+The repository includes a `docker-compose.yml` file that builds the frontend, backend and a PostgreSQL database.
+
+1. Ensure [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed.
+2. From the project root, run:
+   ```bash
+   docker-compose up --build
+   ```
+3. Access the application at `http://localhost:3000` and the API at `http://localhost:3001/api`.
+
+The default database credentials are defined in `docker-compose.yml`. Adjust environment variables as needed.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY tsconfig.json ./
+COPY src ./src
+EXPOSE 3001
+CMD ["npx", "ts-node", "src/server.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: profit_tracker
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/profit_tracker
+      JWT_SECRET: supersecret
+      CLIENT_URL: http://localhost:3000
+    ports:
+      - "3001:3001"
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    environment:
+      VITE_API_URL: http://localhost:3001/api
+    ports:
+      - "3000:4173"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist"]


### PR DESCRIPTION
## Summary
- add Dockerfiles and ignores for both frontend and backend
- add docker-compose to orchestrate services
- document Docker usage in README

## Testing
- `npm install` and `npm run build` in `frontend`
- `npm install` in `backend` *(build skipped due to TypeScript errors)*
- ❌ `docker-compose config` *(command failed: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684080eec8dc832d8852812b923e7757