### PR TITLE
Change frontend to port 4000

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ below describe how to set up both parts for local development.
    JWT_SECRET=some-secret-key
    # Address of the frontend for CORS. Change if the frontend runs on a
    # different host/port.
-   CLIENT_URL=http://localhost:3000
+   CLIENT_URL=http://localhost:4000
    ```
 4. Start the backend in development mode:
    ```bash
@@ -53,7 +53,7 @@ below describe how to set up both parts for local development.
    ```bash
    npm run dev
    ```
-   The application will open at `http://localhost:3000` and communicate with the
+   The application will open at `http://localhost:4000` and communicate with the
    backend using the URL defined in `VITE_API_URL`.
 
 ## Notes
@@ -73,6 +73,6 @@ The repository includes a `docker-compose.yml` file that builds the frontend, ba
    ```bash
    docker-compose up --build
    ```
-3. Access the application at `http://localhost:3000` and the API at `http://localhost:3001/api`.
+3. Access the application at `http://localhost:4000` and the API at `http://localhost:3001/api`.
 
 The default database credentials are defined in `docker-compose.yml`. Adjust environment variables as needed.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,7 +16,7 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:3000'; // Default if not set
+const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:4000'; // Default if not set
 
 // Middleware
 app.use(cors({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:postgres@db:5432/profit_tracker
       JWT_SECRET: supersecret
-      CLIENT_URL: http://localhost:3000
+      CLIENT_URL: http://localhost:4000
     ports:
       - "3001:3001"
     depends_on:
@@ -28,7 +28,7 @@ services:
     environment:
       VITE_API_URL: http://localhost:3001/api
     ports:
-      - "3000:4173"
+      - "4000:4173"
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- switch default client port from 3000 to 4000

## Testing
- `npm run build` in `frontend`
- `npm run build` in `backend` *(fails: src/middleware/authMiddleware.ts TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68408797126c832d90a22c625c8599f8