### PR TITLE
Fix Express Request typing

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,12 +1,12 @@
 
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import process from 'process';
 
 dotenv.config();
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_SECRET = process.env.JWT_SECRET as string;
 
 if (!JWT_SECRET) {
   console.error("FATAL ERROR: JWT_SECRET is not defined.");
@@ -23,7 +23,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   const token = authHeader.split(' ')[1];
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as { userId: string; email: string; };
+    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload & { userId: string; email: string };
     req.user = { id: decoded.userId, email: decoded.email }; // req.user is now recognized due to express.d.ts
     next();
   } catch (error) {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,6 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- include `.d.ts` files in the backend TypeScript build so express request augmentation is found
- refine auth middleware types for jwt verification

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68408967df34832db2588544c9de9c22