### PR TITLE
docs: clarify default public dev host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,81 @@
 # Profit Tracker
 
-This repository contains a React frontend (Vite) and a Node/Express backend. The
-frontend communicates with the backend through HTTP requests. The instructions
-below describe how to set up both parts for local development.
+Este repositório contém um frontend React (Vite) e um backend Node/Express.
+O frontend se comunica com o backend por meio de requisições HTTP.
+As instruções abaixo mostram como configurar ambas as partes para desenvolvimento local.
 
-## Prerequisites
+## Pré-requisitos
 
-- [Node.js](https://nodejs.org/) (version 18 or higher recommended)
-- A running PostgreSQL instance for the backend
+- [Node.js](https://nodejs.org/) (versão 18 ou superior recomendada)
+- Uma instância do PostgreSQL em execução para o backend
 
-## Running the Backend
+## Executando o Backend
 
-1. Navigate to the `backend` folder:
+1. Navegue até a pasta `backend`:
    ```bash
    cd backend
    ```
-2. Install dependencies:
+2. Instale as dependências:
    ```bash
    npm install
    ```
-3. Create a `.env` file inside `backend` with the following variables:
+3. Crie um arquivo `.env` dentro de `backend` com as seguintes variáveis (ajuste
+   `CLIENT_URL` caso o frontend seja servido de outro host/porta):
    ```bash
    DATABASE_URL=postgres://user:password@localhost:5432/profit_tracker
    JWT_SECRET=some-secret-key
-   # Address of the frontend for CORS. Change if the frontend runs on a
-   # different host/port.
+   # Endereço do frontend para CORS.
+   # Altere "localhost" para o IP público se expor o Vite em 0.0.0.0:4000.
    CLIENT_URL=http://localhost:4000
    ```
-4. Start the backend in development mode:
+4. Inicie o backend em modo de desenvolvimento:
    ```bash
    npm run dev
    ```
-   The API will be available at `http://localhost:3001/api`.
+   A API estará disponível em `http://localhost:3001/api`.
 
-## Running the Frontend
+## Executando o Frontend
 
-1. Navigate to the `frontend` folder:
+1. Navegue até a pasta `frontend`:
    ```bash
    cd frontend
    ```
-2. Install dependencies:
+2. Instale as dependências:
    ```bash
    npm install
    ```
-3. Create a `.env.local` file for Vite environment variables (optional):
+3. Crie um arquivo `.env.local` para variáveis de ambiente do Vite (opcional):
    ```bash
    GEMINI_API_KEY=your-gemini-key
-   # Override the backend URL if it is not http://localhost:3001/api
+   # Sobrescreva a URL do backend caso não seja http://localhost:3001/api
    VITE_API_URL=http://localhost:3001/api
    ```
-4. Start the frontend:
+4. Inicie o frontend:
    ```bash
    npm run dev
    ```
-   The application will open at `http://localhost:4000` and communicate with the
-   backend using the URL defined in `VITE_API_URL`.
+   O script `dev` já expõe o servidor de desenvolvimento em todas as interfaces
+   de rede (`0.0.0.0`) na porta `4000`. A aplicação poderá ser acessada pelo IP
+   público da máquina e se comunicará com o backend usando a URL definida em
+   `VITE_API_URL`.
 
-## Notes
+## Observações
 
-- The frontend uses the `VITE_API_URL` variable in `utils/apiClient.ts` to decide
-  which backend URL to call. If this variable is not provided, it defaults to
+- O frontend utiliza a variável `VITE_API_URL` em `utils/apiClient.ts` para decidir
+  qual URL do backend chamar. Se essa variável não for fornecida, o padrão é
   `http://localhost:3001/api`.
-- When deploying, make sure both the backend and frontend are configured with
-  the correct environment variables for your production environment.
+- Ao fazer o deploy, verifique se tanto o backend quanto o frontend estão
+  configurados com as variáveis de ambiente corretas para o seu ambiente de produção.
 
-## Running with Docker
+## Executando com Docker
 
-The repository includes a `docker-compose.yml` file that builds the frontend, backend and a PostgreSQL database.
+O repositório inclui um arquivo `docker-compose.yml` que monta o frontend, o backend e um banco PostgreSQL.
 
-1. Ensure [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed.
-2. From the project root, run:
+1. Certifique-se de que [Docker](https://docs.docker.com/get-docker/) e [Docker Compose](https://docs.docker.com/compose/install/) estão instalados.
+2. A partir da raiz do projeto, execute:
    ```bash
    docker-compose up --build
    ```
-3. Access the application at `http://localhost:4000` and the API at `http://localhost:3001/api`.
+3. Acesse a aplicação em `http://localhost:4000` e a API em `http://localhost:3001/api`.
 
-The default database credentials are defined in `docker-compose.yml`. Adjust environment variables as needed.
+As credenciais padrão do banco estão definidas em `docker-compose.yml`. Ajuste as variáveis de ambiente conforme necessário.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0 --port 4000",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- expose Vite dev server on 0.0.0.0 by default
- document access through public IP in the Portuguese README

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684091360b9c832d8c58e3c533ce9c85