### PR TITLE
Create tables at startup

### DIFF
--- a/backend/src/db/tableSetup.ts
+++ b/backend/src/db/tableSetup.ts
@@ -1,0 +1,102 @@
+import { query } from '../db';
+
+export const createTablesSQL = `
+  CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    username VARCHAR(100),
+    avatar_url VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS dashboards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, name)
+  );
+
+  CREATE TABLE IF NOT EXISTS app_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+    currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
+    enable_notifications BOOLEAN DEFAULT FALSE,
+    notification_time VARCHAR(5) DEFAULT '18:00', -- HH:MM
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, dashboard_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS initial_balances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+    balance NUMERIC(15, 2) NOT NULL,
+    currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, dashboard_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS daily_entries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+    date_key DATE NOT NULL,
+    final_balance NUMERIC(15, 2) NOT NULL,
+    tags TEXT[],
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, dashboard_id, date_key)
+  );
+
+  CREATE TABLE IF NOT EXISTS goals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+    type VARCHAR(10) NOT NULL, -- 'daily', 'weekly', 'monthly'
+    amount NUMERIC(15, 2) NOT NULL,
+    applies_to VARCHAR(20) NOT NULL, -- 'YYYY-MM-DD', 'YYYY-WNN', 'YYYY-MM'
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT check_goal_type CHECK (type IN ('daily', 'weekly', 'monthly'))
+  );
+
+  -- Trigger function to update 'updated_at' columns
+  CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE plpgsql;
+
+  -- Apply trigger to tables that have 'updated_at'
+  DO $$
+  DECLARE
+    t_name TEXT;
+  BEGIN
+    FOR t_name IN SELECT table_name FROM information_schema.columns WHERE column_name = 'updated_at' AND table_schema = current_schema()
+    LOOP
+      EXECUTE format('DROP TRIGGER IF EXISTS set_timestamp ON %I;', t_name);
+      EXECUTE format('CREATE TRIGGER set_timestamp BEFORE UPDATE ON %I FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();', t_name);
+    END LOOP;
+  END;
+  $$;
+`;
+
+export async function createTablesIfNotExist() {
+  try {
+    await query(createTablesSQL);
+    console.log('Tables checked/created successfully.');
+  } catch (error) {
+    console.error('Error creating tables:', error);
+    throw error;
+  }
+}

--- a/backend/src/routes/setupRoutes.ts
+++ b/backend/src/routes/setupRoutes.ts
@@ -1,123 +1,15 @@
 
 import { Router, Request, Response } from 'express';
-import { Pool } from 'pg';
-import fs from 'fs/promises';
 import path from 'path';
 import dotenv from 'dotenv';
 import { query } from '../db'; // Main query function using the pool from db.ts
 import process from 'process';
+import { createTablesIfNotExist } from '../db/tableSetup';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') }); // Ensure .env from backend root is loaded
 
 const router = Router();
 
-// SQL for table creation (idempotent)
-const createTablesSQL = `
-  CREATE TABLE IF NOT EXISTS users (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    email VARCHAR(255) UNIQUE NOT NULL,
-    password_hash VARCHAR(255) NOT NULL,
-    username VARCHAR(100),
-    avatar_url VARCHAR(255),
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-  );
-
-  CREATE TABLE IF NOT EXISTS dashboards (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    name VARCHAR(100) NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (user_id, name) 
-  );
-
-  CREATE TABLE IF NOT EXISTS app_settings (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
-    currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
-    enable_notifications BOOLEAN DEFAULT FALSE,
-    notification_time VARCHAR(5) DEFAULT '18:00', -- HH:MM
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (user_id, dashboard_id)
-  );
-
-  CREATE TABLE IF NOT EXISTS initial_balances (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
-    balance NUMERIC(15, 2) NOT NULL,
-    currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (user_id, dashboard_id)
-  );
-
-  CREATE TABLE IF NOT EXISTS daily_entries (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
-    date_key DATE NOT NULL,
-    final_balance NUMERIC(15, 2) NOT NULL,
-    tags TEXT[],
-    notes TEXT,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (user_id, dashboard_id, date_key)
-  );
-
-  CREATE TABLE IF NOT EXISTS goals (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    dashboard_id UUID NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
-    type VARCHAR(10) NOT NULL, -- 'daily', 'weekly', 'monthly'
-    amount NUMERIC(15, 2) NOT NULL,
-    applies_to VARCHAR(20) NOT NULL, -- 'YYYY-MM-DD', 'YYYY-WNN', 'YYYY-MM'
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    -- Consider unique constraint if needed: UNIQUE(user_id, dashboard_id, type, applies_to) 
-    -- but this might be too restrictive if users want multiple goals of same type for same period (e.g. different amounts)
-    -- Current app design seems to imply one goal of a type per period, so a unique constraint might be appropriate.
-    -- For now, let's assume the application logic handles one-goal-per-type-period if needed.
-    CONSTRAINT check_goal_type CHECK (type IN ('daily', 'weekly', 'monthly'))
-  );
-
-  -- Trigger function to update 'updated_at' columns
-  CREATE OR REPLACE FUNCTION trigger_set_timestamp()
-  RETURNS TRIGGER AS $$
-  BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
-  END;
-  $$ LANGUAGE plpgsql;
-
-  -- Apply trigger to tables that have 'updated_at'
-  DO $$
-  DECLARE
-    t_name TEXT;
-  BEGIN
-    FOR t_name IN SELECT table_name FROM information_schema.columns WHERE column_name = 'updated_at' AND table_schema = current_schema()
-    LOOP
-      -- Drop existing trigger first if it exists, to make this idempotent
-      EXECUTE format('DROP TRIGGER IF EXISTS set_timestamp ON %I;', t_name);
-      EXECUTE format('CREATE TRIGGER set_timestamp BEFORE UPDATE ON %I FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();', t_name);
-    END LOOP;
-  END;
-  $$;
-`;
-
-// Utility function to create tables if they don't exist using the main pool
-async function createTablesIfNotExist() {
-  try {
-    await query(createTablesSQL);
-    console.log("Tables checked/created successfully.");
-  } catch (error) {
-    console.error("Error creating tables:", error);
-    throw error; // Re-throw to be caught by the route handler
-  }
-}
 
 // GET /api/setup/status
 // Checks if the backend considers itself configured (e.g., DATABASE_URL is set and DB is accessible).

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,7 +10,8 @@ import initialBalanceRoutes from './routes/initialBalanceRoutes';
 import entriesRoutes from './routes/entriesRoutes';
 import goalsRoutes from './routes/goalsRoutes';
 import setupRoutes from './routes/setupRoutes'; 
-import dashboardRoutes from './routes/dashboardRoutes'; 
+import dashboardRoutes from './routes/dashboardRoutes';
+import { createTablesIfNotExist } from './db/tableSetup';
 
 dotenv.config();
 
@@ -59,13 +60,19 @@ const globalErrorHandler: ErrorRequestHandler = (err, req: Request, res: Respons
 app.use(globalErrorHandler);
 
 
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
   console.log(`Server listening on port ${PORT}`);
   console.log(`Accepting requests from client at: ${CLIENT_URL}`);
   if(!process.env.DATABASE_URL) {
     console.warn("WARNING: DATABASE_URL environment variable is not set!");
   }
-   if(!process.env.JWT_SECRET) {
+  if(!process.env.JWT_SECRET) {
     console.warn("WARNING: JWT_SECRET environment variable is not set!");
+  }
+
+  try {
+    await createTablesIfNotExist();
+  } catch (err) {
+    console.error('Failed to ensure database tables:', err);
   }
 });


### PR DESCRIPTION
## Summary
- ensure tables exist on startup
- refactor setup routes to reuse common DB init logic

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409e34d5d8832dad3c8424e37d18c7