### PR TITLE
Fix duplicate key in days of week list

### DIFF
--- a/frontend/utils/dateUtils.ts
+++ b/frontend/utils/dateUtils.ts
@@ -35,7 +35,15 @@ export const MONTH_NAMES_PT = [
   "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
 ];
 
-export const DAYS_OF_WEEK_PT_SHORT = ["Do", "Se", "Te", "Qu", "Qi", "Se", "Sá"];
+export const DAYS_OF_WEEK_PT_SHORT = [
+  "Dom",
+  "Seg",
+  "Ter",
+  "Qua",
+  "Qui",
+  "Sex",
+  "Sáb",
+];
 export const DAYS_OF_WEEK_PT_FULL = ["Domingo", "Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira", "Sábado"];
 
 


### PR DESCRIPTION
## Summary
- ensure short day names are unique

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: missing test script)

------
https://chatgpt.com/codex/tasks/task_e_6840aed64b5c832db1e2c5fa78cfe246