### PR TITLE
Disable ETag in backend server

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,8 @@ import dashboardRoutes from './routes/dashboardRoutes';
 dotenv.config();
 
 const app = express();
+// Disable ETag headers to avoid 304 responses that break fetch handling
+app.disable('etag');
 const PORT = process.env.PORT || 3001;
 const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173'; // Default if not set
 


### PR DESCRIPTION
## Summary
- disable Express' built-in ETag

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68417fd4d724832da480e970d70e6985