### PR TITLE
Fix entry date keys and API URL

### DIFF
--- a/backend/src/routes/entriesRoutes.ts
+++ b/backend/src/routes/entriesRoutes.ts
@@ -19,8 +19,9 @@ router.get('/', authMiddleware, async (req: Request, res: Response) => {
     // Transform to the { [dateKey]: DailyEntry } structure expected by frontend
     const entriesMap: { [dateKey: string]: any } = {};
     result.rows.forEach(row => {
-      entriesMap[row.date_key] = {
-        id: row.id, 
+      const dateKey = row.date_key instanceof Date ? row.date_key.toISOString().split('T')[0] : row.date_key;
+      entriesMap[dateKey] = {
+        id: row.id,
         finalBalance: parseFloat(row.final_balance),
         tags: row.tags || [],
         notes: row.notes || ''

--- a/frontend/utils/apiClient.ts
+++ b/frontend/utils/apiClient.ts
@@ -1,5 +1,9 @@
 
-const API_BASE_URL = 'http://localhost:3001/api'; // Default backend URL. Replace with import.meta.env.VITE_API_URL if using Vite.
+// Use backend URL from environment when available (Vite's VITE_API_URL)
+// fall back to localhost during development.
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_URL) ||
+  'http://localhost:3001/api';
 
 interface ApiClientOptions extends RequestInit {
   useAuth?: boolean;


### PR DESCRIPTION
## Summary
- normalize date keys in entries API to `YYYY-MM-DD`
- allow frontend API client to use `VITE_API_URL`

## Testing
- `npm run build` in `backend`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684187e938c0832da06b61839d7a6ddc