### PR TITLE
Add dashboard switcher to settings

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -464,6 +464,7 @@ const App: React.FC = () => {
             currentSettings={settings}
             onSave={handleSaveSettings}
             onOpenGoalManager={() => { setIsSettingsModalOpen(false); setIsGoalModalOpen(true); }}
+            onSwitchDashboard={() => { setIsSettingsModalOpen(false); setActiveDashboard(null); }}
         />
       )}
       {activeDashboard && (

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import type { AppSettings, CurrencyCode } from '../types';
-import { XMarkIcon, CurrencyDollarIcon, BellIcon, TrophyIcon } from './Icons';
+import { XMarkIcon, CurrencyDollarIcon, BellIcon, TrophyIcon, ArrowsRightLeftIcon } from './Icons';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -9,6 +9,7 @@ interface SettingsModalProps {
   currentSettings: AppSettings;
   onSave: (settings: AppSettings) => void;
   onOpenGoalManager: () => void;
+  onSwitchDashboard: () => void;
 }
 
 const availableCurrencies: { code: CurrencyCode; name: string }[] = [
@@ -17,7 +18,7 @@ const availableCurrencies: { code: CurrencyCode; name: string }[] = [
   { code: 'EUR', name: 'Euro (EUR)' },
 ];
 
-export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, currentSettings, onSave, onOpenGoalManager }) => {
+export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, currentSettings, onSave, onOpenGoalManager, onSwitchDashboard }) => {
   const [settings, setSettings] = useState<AppSettings>(() => ({
     ...currentSettings,
     notificationTime: currentSettings.notificationTime || '',
@@ -122,14 +123,28 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, c
             <label className="flex items-center text-sm font-medium text-slate-300 mb-1">
                 <TrophyIcon className="w-5 h-5 mr-2 text-slate-400" /> Gerenciar Metas
             </label>
-             <button
-                onClick={onOpenGoalManager}
-                className="w-full px-4 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md transition-colors duration-150 flex items-center justify-center space-x-2"
+           <button
+               onClick={onOpenGoalManager}
+               className="w-full px-4 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md transition-colors duration-150 flex items-center justify-center space-x-2"
+           >
+               <TrophyIcon className="w-5 h-5" />
+               <span>Abrir Gerenciador de Metas</span>
+           </button>
+          </div>
+
+          {/* Dashboard Switch */}
+          <div>
+            <label className="flex items-center text-sm font-medium text-slate-300 mb-1">
+                <ArrowsRightLeftIcon className="w-5 h-5 mr-2 text-slate-400" /> Trocar Dashboard
+            </label>
+            <button
+                onClick={() => { onClose(); onSwitchDashboard(); }}
+                className="w-full px-4 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md transition-colors duration-150 flex items-center justify-center space-x-2"
             >
-                <TrophyIcon className="w-5 h-5" />
-                <span>Abrir Gerenciador de Metas</span>
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>Escolher Outro Dashboard</span>
             </button>
-           </div>
+          </div>
 
 
           <div className="mt-8 pt-6 border-t border-slate-700/50">


### PR DESCRIPTION
## Summary
- expose new `onSwitchDashboard` handler to `SettingsModal`
- show a button inside settings to open dashboard selection
- reset `activeDashboard` when using the new button

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*
- `npm run build` in `frontend` *(fails: vite not found)*
- `npm run build` in `backend` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68418c183dac832d8087fa5b7a2dcb90