### PR TITLE
Change icons design

### DIFF
--- a/frontend/components/Icons.tsx
+++ b/frontend/components/Icons.tsx
@@ -57,8 +57,11 @@ export const Cog6ToothIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) =>
 );
 
 export const Cog8ToothSolidIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  // Replaced original cog icon with the wrench-screwdriver icon for a new design
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
-    <path fillRule="evenodd" d="M11.078 2.25c-.917 0-1.699.663-1.944 1.546A2.569 2.569 0 009.32 5.43a2.638 2.638 0 00-2.097.437c-.917.546-1.393 1.681-.976 2.626C6.728 9.482 6.31 10.33 6.31 11.25c0 .92.418 1.768.992 2.738.417.945-.059 2.08-.976 2.626a2.638 2.638 0 002.097.437 2.569 2.569 0 001.813 1.639c.245.883 1.027 1.546 1.944 1.546H12c.917 0 1.699-.663 1.944-1.546a2.569 2.569 0 001.813-1.639 2.638 2.638 0 002.097-.437c.917-.546 1.393-1.681.976-2.626-.459-.991-.041-1.838-.041-2.738 0-.9.418-1.748.992-2.738.417-.945-.059-2.08-.976-2.626a2.638 2.638 0 00-2.097-.437 2.569 2.569 0 00-1.813-1.639C13.699 2.913 12.917 2.25 12 2.25h-.922zM12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" clipRule="evenodd" />
+    <path fillRule="evenodd" d="M12 6.75a5.25 5.25 0 0 1 6.775-5.025.75.75 0 0 1 .313 1.248l-3.32 3.319c.063.475.276.934.641 1.299.365.365.824.578 1.3.64l3.318-3.319a.75.75 0 0 1 1.248.313 5.25 5.25 0 0 1-5.472 6.756c-1.018-.086-1.87.1-2.309.634L7.344 21.3A3.298 3.298 0 1 1 2.7 16.657l8.684-7.151c.533-.44.72-1.291.634-2.309A5.342 5.342 0 0 1 12 6.75ZM4.117 19.125a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75h-.008a.75.75 0 0 1-.75-.75v-.008Z" clipRule="evenodd" />
+    <path d="m10.076 8.64-2.201-2.2V4.874a.75.75 0 0 0-.364-.643l-3.75-2.25a.75.75 0 0 0-.916.113l-.75.75a.75.75 0 0 0-.113.916l2.25 3.75a.75.75 0 0 0 .643.364h1.564l2.062 2.062 1.575-1.297Z" />
+    <path fillRule="evenodd" d="m12.556 17.329 4.183 4.182a3.375 3.375 0 0 0 4.773-4.773l-3.306-3.305a6.803 6.803 0 0 1-1.53.043c-.394-.034-.682-.006-.867.042a.589.589 0 0 0-.167.063l-3.086 3.748Zm3.414-1.36a.75.75 0 0 1 1.06 0l1.875 1.876a.75.75 0 1 1-1.06 1.06L15.97 17.03a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
   </svg>
 );
 
@@ -143,8 +146,9 @@ export const CloudArrowUpIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props)
 );
 
 export const ServerStackIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  // Replaced original server stack icon with a computer desktop icon for a fresh look
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 7.5l3 2.25-3 2.25m0 0l3 2.25-3 2.25m0-13.5l3 2.25-3 2.25m12.75 13.5l3-2.25-3-2.25m0 0l3-2.25-3-2.25m0 13.5l3-2.25-3-2.25M6.75 7.5h10.5m-10.5 13.5h10.5" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25" />
   </svg>
 );
 


### PR DESCRIPTION
## Summary
- update Cog8ToothSolidIcon design to use a wrench-screwdriver motif
- replace ServerStackIcon with a computer-desktop outline

## Testing
- `npm exec vite build` *(fails: Need to install the following packages: vite@6.3.5)*
- `npm run build` in `backend` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68418ec2ec64832dae02129bd9b0e2c4