### PR TITLE
Fix token initialization

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -39,6 +39,11 @@ const App: React.FC = () => {
     return storedUser ? JSON.parse(storedUser) : null;
   });
 
+  // Ensure apiClient always has the latest token, including on initial load
+  useEffect(() => {
+    apiClient.setToken(token);
+  }, [token]);
+
   const [dashboards, setDashboards] = useState<Dashboard[] | null>(null);
   const [activeDashboard, setActiveDashboard] = useState<Dashboard | null>(null);
   


### PR DESCRIPTION
## Summary
- set auth token on initial load so dashboards can be fetched

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd backend && npm test` *(fails: Error: no test specified)*
- `cd ../frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684192800524832d858ded7ffcaffc73