### PR TITLE
Fix App.tsx missing semicolon due to useEffect mistake

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -132,8 +132,7 @@ const App: React.FC = () => {
 
 
   // Data load effect (scoped to activeDashboard in Iteration 2)
-  useEffect(() => {
-    const loadAppData = async (showLoading: boolean) => {
+  const loadAppData = useCallback(async (showLoading: boolean) => {
       if (!activeDashboard || !isAuthenticated || !isBackendSetupComplete) {
         if (showLoading) setIsLoading(false);
         return;


### PR DESCRIPTION
## Summary
- fix syntax error in App.tsx by converting `loadAppData` to `useCallback`
- build frontend to ensure compilation works

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68419e04976c832d8d7f78107e23ac07