### PR TITLE
Fix port config for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       VITE_API_URL: http://localhost:3001/api
     ports:
-      - "4000:4173"
+      - "4000:4000"
     depends_on:
       - backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,5 +11,5 @@ FROM node:18-alpine
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 RUN npm install -g serve
-EXPOSE 5173
-CMD ["serve", "-s", "dist"]
+EXPOSE 4000
+CMD ["serve", "-s", "dist", "-l", "4000"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 4000 --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- ensure Vite runs on port 4000 via package.json script
- expose port 4000 in frontend Dockerfile
- map frontend container to port 4000 in docker-compose

## Testing
- `npm run build` in frontend
- `npm run build` in backend

------
https://chatgpt.com/codex/tasks/task_e_6841a2560de4832d88111f527aa694c7