### PR TITLE
Fix Tailwind opacity classes

### DIFF
--- a/frontend/components/DayDetailsModal.tsx
+++ b/frontend/components/DayDetailsModal.tsx
@@ -54,7 +54,7 @@ export const DayDetailsModal: React.FC<DayDetailsModalProps> = ({ isOpen, onClos
         {notes && (
           <div className="mb-6">
             <h3 className="text-sm font-medium text-slate-400 mb-1 flex items-center"><ChatBubbleLeftEllipsisIcon className="w-4 h-4 mr-1.5"/>Anotações</h3>
-            <p className="text-sm text-slate-300 bg-slate-700/50 p-3 rounded whitespace-pre-wrap max-h-40 overflow-y-auto">{notes}</p>
+            <p className="text-sm text-slate-300 bg-slate-700 bg-opacity-50 p-3 rounded whitespace-pre-wrap max-h-40 overflow-y-auto">{notes}</p>
           </div>
         )}
 

--- a/frontend/components/DayTile.tsx
+++ b/frontend/components/DayTile.tsx
@@ -41,10 +41,10 @@ export const DayTile: React.FC<DayTileProps> = ({ dayData, onClick, currency, on
         }
       }
     } else {
-         tileClasses += " bg-slate-800 border border-slate-700/50 ";
+    tileClasses += " bg-slate-800 border border-slate-700 border-opacity-50 ";
     }
   } else {
-    tileClasses += " bg-slate-850 opacity-80 border border-slate-700/30 ";
+    tileClasses += " bg-slate-850 opacity-80 border border-slate-700 border-opacity-30 ";
     textColor = 'text-slate-600';
   }
   
@@ -61,9 +61,9 @@ export const DayTile: React.FC<DayTileProps> = ({ dayData, onClick, currency, on
           {dayNumber}
         </span>
         {hasDetails && (
-           <button 
-            onClick={(e) => { e.stopPropagation(); onShowDetails(dayData);}} 
-            className="p-0.5 rounded hover:bg-slate-500/30 focus:outline-none focus:ring-1 focus:ring-sky-400"
+           <button
+            onClick={(e) => { e.stopPropagation(); onShowDetails(dayData);}}
+            className="p-0.5 rounded hover:bg-slate-500 hover:bg-opacity-30 focus:outline-none focus:ring-1 focus:ring-sky-400"
             aria-label="Ver detalhes do dia"
             >
              <InformationCircleIcon className={`w-4 h-4 ${isCurrentMonth ? 'text-slate-400' : 'text-slate-600'} group-hover:text-sky-300`} />
@@ -81,12 +81,12 @@ export const DayTile: React.FC<DayTileProps> = ({ dayData, onClick, currency, on
         {isCurrentMonth && !entryExists && (dynamicDailyTargetForWeek !== null || dynamicDailyTargetForMonth !== null) && (
              <div className="absolute bottom-0 left-0 right-0 px-0.5 pb-0.5">
                 {dynamicDailyTargetForWeek !== null && dynamicDailyTargetForWeek > 0 && (
-                    <p className="text-[9px] sm:text-[10px] text-sky-400/80 truncate" title={`Alvo dinâmico para a semana: ${formatCurrency(dynamicDailyTargetForWeek, currency)}/dia`}>
+                    <p className="text-[9px] sm:text-[10px] text-sky-400 text-opacity-80 truncate" title={`Alvo dinâmico para a semana: ${formatCurrency(dynamicDailyTargetForWeek, currency)}/dia`}>
                         Sem: {formatCurrency(dynamicDailyTargetForWeek, currency)}
                     </p>
                 )}
                 {dynamicDailyTargetForMonth !== null && dynamicDailyTargetForMonth > 0 && (
-                    <p className="text-[9px] sm:text-[10px] text-indigo-400/80 truncate" title={`Alvo dinâmico para o mês: ${formatCurrency(dynamicDailyTargetForMonth, currency)}/dia`}>
+                    <p className="text-[9px] sm:text-[10px] text-indigo-400 text-opacity-80 truncate" title={`Alvo dinâmico para o mês: ${formatCurrency(dynamicDailyTargetForMonth, currency)}/dia`}>
                         Mês: {formatCurrency(dynamicDailyTargetForMonth, currency)}
                     </p>
                 )}
@@ -98,12 +98,12 @@ export const DayTile: React.FC<DayTileProps> = ({ dayData, onClick, currency, on
       {isCurrentMonth && entryExists && (dynamicDailyTargetForWeek !== null || dynamicDailyTargetForMonth !== null) && (
         <div className="text-center mt-0.5 leading-tight">
             {dynamicDailyTargetForWeek !== null && dynamicDailyTargetForWeek > 0 && (
-                <p className="text-[9px] sm:text-[10px] text-sky-300/70 group-hover:text-sky-200 truncate" title={`Alvo dinâmico para a semana: ${formatCurrency(dynamicDailyTargetForWeek, currency)}/dia`}>
+                <p className="text-[9px] sm:text-[10px] text-sky-300 text-opacity-70 group-hover:text-sky-200 truncate" title={`Alvo dinâmico para a semana: ${formatCurrency(dynamicDailyTargetForWeek, currency)}/dia`}>
                     Alvo Sem: {formatCurrency(dynamicDailyTargetForWeek, currency)}
                 </p>
             )}
             {dynamicDailyTargetForMonth !== null && dynamicDailyTargetForMonth > 0 && (
-                <p className="text-[9px] sm:text-[10px] text-indigo-300/70 group-hover:text-indigo-200 truncate" title={`Alvo dinâmico para o mês: ${formatCurrency(dynamicDailyTargetForMonth, currency)}/dia`}>
+                <p className="text-[9px] sm:text-[10px] text-indigo-300 text-opacity-70 group-hover:text-indigo-200 truncate" title={`Alvo dinâmico para o mês: ${formatCurrency(dynamicDailyTargetForMonth, currency)}/dia`}>
                     Alvo Mês: {formatCurrency(dynamicDailyTargetForMonth, currency)}
                 </p>
             )}
@@ -111,7 +111,7 @@ export const DayTile: React.FC<DayTileProps> = ({ dayData, onClick, currency, on
       )}
       
       {isCurrentMonth && goalProgress && (
-         <div className="w-full bg-slate-600/50 rounded-full h-1.5 mt-auto mb-0.5">
+         <div className="w-full bg-slate-600 bg-opacity-50 rounded-full h-1.5 mt-auto mb-0.5">
             <div 
                 className={`h-1.5 rounded-full ${goalProgress.percentage >= 100 ? 'bg-green-500' : 'bg-sky-500'}`}
                 style={{ width: `${Math.min(goalProgress.percentage, 100)}%` }}

--- a/frontend/components/EntryModal.tsx
+++ b/frontend/components/EntryModal.tsx
@@ -129,7 +129,7 @@ export const EntryModal: React.FC<EntryModalProps> = ({
             />
           </div>
           
-          <div className="text-sm text-slate-400 mb-2 p-3 bg-slate-700/50 rounded-md">
+          <div className="text-sm text-slate-400 mb-2 p-3 bg-slate-700 bg-opacity-50 rounded-md">
             <p>Saldo anterior: {formatCurrency(previousDayBalance, currency)}</p>
             {!isNaN(currentEntryBalanceNum) && (
                  <p>Lucro/Prejuízo do dia: 

--- a/frontend/components/LoginScreen.tsx
+++ b/frontend/components/LoginScreen.tsx
@@ -111,8 +111,8 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ onLoginSuccess }) => {
               </div>
             </div>
 
-            {error && <p className="text-red-400 text-sm text-center bg-red-900/30 p-2 rounded-md">{error}</p>}
-            {message && <p className="text-emerald-400 text-sm text-center bg-emerald-900/30 p-2 rounded-md">{message}</p>}
+            {error && <p className="text-red-400 text-sm text-center bg-red-900 bg-opacity-30 p-2 rounded-md">{error}</p>}
+            {message && <p className="text-emerald-400 text-sm text-center bg-emerald-900 bg-opacity-30 p-2 rounded-md">{message}</p>}
             
             <button
               type="submit"

--- a/frontend/components/PostgresGetStartedScreen.tsx
+++ b/frontend/components/PostgresGetStartedScreen.tsx
@@ -92,7 +92,7 @@ export const PostgresGetStartedScreen: React.FC<PostgresGetStartedScreenProps> =
         </form>
         
         {processMessage && (
-            <div className={`text-sm mt-6 p-3 rounded-md whitespace-pre-wrap ${processErrorOccurred ? 'bg-red-900/40 text-red-300' : 'bg-emerald-900/40 text-emerald-300'}`}>
+            <div className={`text-sm mt-6 p-3 rounded-md whitespace-pre-wrap ${processErrorOccurred ? 'bg-red-900 bg-opacity-40 text-red-300' : 'bg-emerald-900 bg-opacity-40 text-emerald-300'}`}>
                 <p className="font-semibold mb-1">{processErrorOccurred ? 'Erro na Configuração:' : 'Status da Configuração:'}</p>
                 {processMessage.split('\n').map((line, index) => (
                     <span key={index}>{line}<br/></span>

--- a/frontend/components/ReportsView.tsx
+++ b/frontend/components/ReportsView.tsx
@@ -401,7 +401,7 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ entries, initialBalanc
 
       {/* Tag Filter Modal */}
       {showTagFilterModal && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50 backdrop-blur-sm">
+        <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50 backdrop-blur-sm">
           <div className="bg-slate-800 p-6 rounded-lg shadow-xl w-full max-w-md">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-semibold text-white">Selecionar Tags para Filtrar</h3>
@@ -471,7 +471,7 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ entries, initialBalanc
           )}
           
            {/* Export Section */}
-          <div className="mt-8 pt-6 border-t border-slate-700/50">
+          <div className="mt-8 pt-6 border-t border-slate-700 border-opacity-50">
             <h3 className="text-lg font-semibold text-white mb-3">Exportar Dados</h3>
             <div className="flex space-x-3">
                 <button onClick={() => handleExport('csv')} className="px-4 py-2 bg-slate-600 hover:bg-slate-500 text-slate-200 rounded-md text-sm flex items-center">

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -87,7 +87,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, c
             <label className="flex items-center text-sm font-medium text-slate-300 mb-1">
                 <BellIcon className="w-5 h-5 mr-2 text-slate-400" /> Lembretes de Registro
             </label>
-            <div className="flex items-center space-x-4 bg-slate-700/50 p-3 rounded-md">
+            <div className="flex items-center space-x-4 bg-slate-700 bg-opacity-50 p-3 rounded-md">
               <label htmlFor="enableNotifications" className="flex items-center space-x-2 cursor-pointer">
                 <input
                   type="checkbox"
@@ -147,7 +147,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, c
           </div>
 
 
-          <div className="mt-8 pt-6 border-t border-slate-700/50">
+          <div className="mt-8 pt-6 border-t border-slate-700 border-opacity-50">
             <button
               onClick={handleSave}
               className="w-full bg-sky-600 hover:bg-sky-700 text-white font-semibold py-3 rounded-md transition-colors duration-150"

--- a/frontend/components/WeekSummaryTile.tsx
+++ b/frontend/components/WeekSummaryTile.tsx
@@ -40,12 +40,12 @@ export const WeekSummaryTile: React.FC<WeekSummaryTileProps> = ({ date, isCurren
   const textColor = isCurrentMonth ? 'text-slate-300' : 'text-slate-600';
 
   if (isCurrentMonth) {
-    tileClasses += " bg-slate-800 hover:bg-slate-700 border border-slate-700/50 ";
+    tileClasses += " bg-slate-800 hover:bg-slate-700 border border-slate-700 border-opacity-50 ";
     if (summaryData && summaryData.entryCount > 0) {
-      tileClasses += " bg-slate-750/80 "; 
+      tileClasses += " bg-slate-750 bg-opacity-80 ";
     }
   } else {
-    tileClasses += " bg-slate-850 opacity-80 border border-slate-700/30 ";
+    tileClasses += " bg-slate-850 opacity-80 border border-slate-700 border-opacity-30 ";
   }
 
   const isToday = new Date().toDateString() === date.toDateString();
@@ -84,7 +84,7 @@ export const WeekSummaryTile: React.FC<WeekSummaryTileProps> = ({ date, isCurren
          </div>
       )}
       {isCurrentMonth && summaryData?.goalProgress && (
-         <div className="w-full bg-slate-600/50 rounded-full h-1.5 mt-auto mb-0.5">
+         <div className="w-full bg-slate-600 bg-opacity-50 rounded-full h-1.5 mt-auto mb-0.5">
             <div 
                 className={`h-1.5 rounded-full ${summaryData.goalProgress.percentage >= 100 ? 'bg-green-500' : 'bg-sky-500'}`}
                 style={{ width: `${Math.min(summaryData.goalProgress.percentage, 100)}%` }}


### PR DESCRIPTION
## Summary
- replace Tailwind `/xx` opacity utilities with `bg-opacity-*` and `text-opacity-*`
- ensure border opacity classes are explicit

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: JSX element implicitly has type 'any')*

------
https://chatgpt.com/codex/tasks/task_e_6841d0a92454832da46d7406e164a39e