### PR TITLE
Update docker-compose to use .env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=profit_tracker
+DB_PORT=5432
+DATABASE_URL=postgres://postgres:postgres@db:5432/profit_tracker
+JWT_SECRET=supersecret
+CLIENT_URL=http://localhost:4000
+BACKEND_PORT=3001
+VITE_API_URL=http://localhost:3001/api
+FRONTEND_PORT=4000

--- a/README.md
+++ b/README.md
@@ -79,12 +79,17 @@ As instruções abaixo mostram como configurar ambas as partes para desenvolvime
 ## Executando com Docker
 
 O repositório inclui um arquivo `docker-compose.yml` que monta o frontend, o backend e um banco PostgreSQL.
+As variáveis de ambiente podem ser definidas em um arquivo `.env` na raiz do projeto (veja `.env.example`).
 
 1. Certifique-se de que [Docker](https://docs.docker.com/get-docker/) e [Docker Compose](https://docs.docker.com/compose/install/) estão instalados.
-2. A partir da raiz do projeto, execute:
+2. Copie o arquivo de exemplo e ajuste as variáveis desejadas:
+   ```bash
+   cp .env.example .env
+   ```
+3. A partir da raiz do projeto, execute:
    ```bash
    docker-compose up --build
    ```
-3. Acesse a aplicação em `http://localhost:4000` e a API em `http://localhost:3001/api`.
+4. Acesse a aplicação em `http://localhost:4000` e a API em `http://localhost:3001/api`.
 
-As credenciais padrão do banco estão definidas em `docker-compose.yml`. Ajuste as variáveis de ambiente conforme necessário.
+As credenciais padrão do banco e as portas podem ser sobrescritas pelas variáveis definidas no arquivo `.env` ou diretamente no ambiente.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,31 +4,31 @@ services:
     image: postgres:15
     restart: always
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: profit_tracker
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-profit_tracker}
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
 
   backend:
     build: ./backend
     environment:
-      DATABASE_URL: postgres://postgres:postgres@db:5432/profit_tracker
-      JWT_SECRET: supersecret
-      CLIENT_URL: http://localhost:4000
+      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:postgres@db:5432/profit_tracker}
+      JWT_SECRET: ${JWT_SECRET:-supersecret}
+      CLIENT_URL: ${CLIENT_URL:-http://localhost:4000}
     ports:
-      - "3001:3001"
+      - "${BACKEND_PORT:-3001}:3001"
     depends_on:
       - db
 
   frontend:
     build: ./frontend
     environment:
-      VITE_API_URL: http://localhost:3001/api
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:3001/api}
     ports:
-      - "4000:4000"
+      - "${FRONTEND_PORT:-4000}:4000"
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- allow docker-compose to reference environment variables
- document .env usage for Docker workflow
- add `.env.example` demonstrating available variables

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e69b6a38832da5517b3fa3716ef5